### PR TITLE
remove facebook integration for announcements

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,9 +40,6 @@
     "tw_access_token": {"type": "String"},
     "tw_token_secret": {"type": "String"}
   },
-  "fb": {
-    "access_token": {"type": "String"}
-  },
   "firebase": {
     "key": {"type": "String"}
   }

--- a/config.template.json
+++ b/config.template.json
@@ -39,9 +39,6 @@
     "tw_access_token": "",
     "tw_token_secret": ""
   },
-  "fb": {
-    "access_token": ""
-  },
   "firebase": {
     "key":""
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "express": "~4.13.1",
     "express-flash": "0.0.2",
     "express-validator": "^2.13.0",
-    "fbgraph": "^1.2.0",
     "fcm-push": "^1.0.7",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",

--- a/routes/api/admin.js
+++ b/routes/api/admin.js
@@ -29,8 +29,6 @@ var OAuth = require('oauth');
 var util = require('../../util/util.js');
 
 var Twitter = require('twitter');
-var graph = require('fbgraph');
-graph.setAccessToken(config.fb.access_token);
 
 // All routes
 router.patch('/user/:pubid/setStatus', setUserStatus);
@@ -786,13 +784,6 @@ function postAnnouncement(req, res, next) {
                 };
 
                 fcm.send(message, function(err,response){
-                });
-            }
-
-            if (req.body.facebook) {
-                graph.post("/feed", {message: req.body.message}, function (err, res) {
-                    if (err) console.log('ERROR posting to Facebook: ' + err);
-                    console.log(res);
                 });
             }
 

--- a/views/admin/index.jade
+++ b/views/admin/index.jade
@@ -91,10 +91,6 @@ block append admin_content
                         | &nbsp;Mobile
                     br
                     label
-                        input#facebook(type='checkbox', name='facebook', value='true', checked=false)
-                        | &nbsp;Facebook
-                    br
-                    label
                         input#twitter(type='checkbox', name='twitter', value='true', checked=false)
                         | &nbsp;Twitter
                     br


### PR DESCRIPTION
It seem does not seem like a good idea to integrate facebook with our announcements system as in #20, so this removes the ui/code skeletons for the facebook option.