### PR TITLE
add option to narrow search by notification status

### DIFF
--- a/models/searchable.js
+++ b/models/searchable.js
@@ -46,6 +46,10 @@ searchable.user = [
         path: "internal.status"
     },
     {
+        alias: "notificationStatus",
+        path: "internal.notificationStatus"
+    },
+    {
         alias: "role"
     },
     {

--- a/views/admin/search/search.jade
+++ b/views/admin/search/search.jade
@@ -48,6 +48,15 @@ block admin_content
                     checked: input.status || "",
                     name: "status"
                 })
+            .form-group.category-input
+                br
+                label Narrow by Notification Status:
+                br
+                +generateInlineRadio(["", "Accepted", "Waitlisted", "Rejected", "Pending"], {
+                    label: "None Accepted Waitlisted Rejected Pending".split(" "),
+                    checked: input.notificationStatus || "",
+                    name: "notificationStatus"
+                })
             .form-group
                 .checkbox
                     label


### PR DESCRIPTION
I simply created one more option to filter search results by notification status. This might be an overkill for this issue, but hopefully useful for the future. 